### PR TITLE
Add session.previousRequest variable to store the request that initiated the login

### DIFF
--- a/lib/ensureLoggedIn.js
+++ b/lib/ensureLoggedIn.js
@@ -41,7 +41,6 @@ module.exports = function ensureLoggedIn(options) {
   var setReturnTo = (options.setReturnTo === undefined) ? true : options.setReturnTo;
   
   return function(req, res, next) {
-    console.log(req.isAuthenticated)
     if (!req.isAuthenticated || !req.isAuthenticated()) {
       if (setReturnTo && req.session) {
         req.session.returnTo = req.url;

--- a/lib/ensureLoggedIn.js
+++ b/lib/ensureLoggedIn.js
@@ -41,12 +41,24 @@ module.exports = function ensureLoggedIn(options) {
   var setReturnTo = (options.setReturnTo === undefined) ? true : options.setReturnTo;
   
   return function(req, res, next) {
+    console.log(req.isAuthenticated)
     if (!req.isAuthenticated || !req.isAuthenticated()) {
       if (setReturnTo && req.session) {
         req.session.returnTo = req.url;
+        req.session.previousRequest = {
+          params : req.params,
+          query : req.query,
+          body : req.body,
+          files : req.files
+        };
+        req.session.save(function(){
+          return res.redirect(url)
+        })
+      } else {
+        return res.redirect(url);
       }
-      return res.redirect(url);
+    } else {
+      next();
     }
-    next();
   }
 }


### PR DESCRIPTION
I was using this lib to redirect to an upload form, and needed to retain the Files, params, body, and query of the initiating request - added a new variable where this info can be accessed.
