### PR TITLE
401 status code instead of redirect when securing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ Simply mount Passport's `authenticate()` middleware at the login route.
 Upon log in, Passport will notice the `returnTo` URL saved in the session and
 redirect the user back to `/settings`.
 
+#### Return HTTP 401
+
+In this example, an application has API that only should be accessible by authorized users. A user must be logged in
+before API calls can be accepted.
+
+    app.get('/api',
+        ensureLoggedIn({sendHTTPCode:true},
+        function(req, res){ ... });
+
+If a user is not logged in and client-side script is trying to make API calls, the application will return
+401 (Unauthorized) status code that should be handled by the script.
+
 #### Step By Step
 
 If the user is not logged in, the sequence of requests and responses that take

--- a/lib/ensureLoggedIn.js
+++ b/lib/ensureLoggedIn.js
@@ -12,6 +12,7 @@
  * Options:
  *   - `redirectTo`   URL to redirect to for login, defaults to _/login_
  *   - `setReturnTo`  set redirectTo in session, defaults to _true_
+ *   - `sendHTTPCode` send 401 (Unauthorized) HTTP code instead of redirecting to _/login_. Overrides other options.
  *
  * Examples:
  *
@@ -27,6 +28,10 @@
  *       ensureLoggedIn({ redirectTo: '/session/new', setReturnTo: false }),
  *       function(req, res) { ... });
  *
+ *     app.get('/api/profile',
+ *      ensureLoggedIn({sendHTTPCode:true}),
+ *      function(req, res){ ... });
+ *
  * @param {Object} options
  * @return {Function}
  * @api public
@@ -39,13 +44,18 @@ module.exports = function ensureLoggedIn(options) {
   
   var url = options.redirectTo || '/login';
   var setReturnTo = (options.setReturnTo === undefined) ? true : options.setReturnTo;
+  var sendHTTPCode = (options.sendHTTPCode === undefined) ? false : options.sendHTTPCode;
   
   return function(req, res, next) {
     if (!req.isAuthenticated || !req.isAuthenticated()) {
-      if (setReturnTo && req.session) {
-        req.session.returnTo = req.originalUrl || req.url;
+      if(sendHTTPCode){
+          return res.send(401);
+      }else{
+          if (setReturnTo && req.session) {
+            req.session.returnTo = req.originalUrl || req.url;
+          }
+          return res.redirect(url);
       }
-      return res.redirect(url);
     }
     next();
   }


### PR DESCRIPTION
I added an option to send 401 (Unauthorized) instead of redirecting to '/login' by default. This should be useful for securing APIs when accessed by client-side script. 
