### PR TITLE
Require authentication on all paths but allow assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ what happens:
 4. User's browser follows redirect to `GET /settings`
     - Now authenticated, application renders settings page
 
+#### Authenticate All Paths With a Few Exceptions
+
+If you want to require authentication for all paths:
+
+    app.all('*', connect.ensureLoggedIn('/login'), function(req, res, next){
+      next(); 
+    });
+
+but want a select few paths (primarily assets) pages to not 
+require authentication, pass an array of strings (into allowedPaths) of
+allowed paths that should not require authentication.
+ 
+Example:
+    app.all('*', connect.ensureLoggedIn('/login', [
+      '/stylesheets/login.css',
+      '/javascripts/login.js',
+      '/images/logo.png',
+      '/images/favicon.png'
+    ]), function(req, res, next){
+      next(); 
+    });
+
 ## Tests
 
     $ npm install --dev

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ require authentication, pass an array of strings (into allowedPaths) of
 allowed paths that should not require authentication.
  
 Example:
+
     app.all('*', connect.ensureLoggedIn('/login', [
       '/stylesheets/login.css',
       '/javascripts/login.js',

--- a/lib/ensureLoggedIn.js
+++ b/lib/ensureLoggedIn.js
@@ -5,6 +5,24 @@
  * that is unauthenticated, the request will be redirected to a login page (by
  * default to `/login`).
  *
+ * If you want to require authentication for all paths:
+ *    app.all('*', connect.ensureLoggedIn('/login'), function(req, res, next){
+ *      next(); 
+ *    });
+ * but want a select few paths (primarily assets) pages to not 
+ * require authentication, pass an array of strings (into allowedPaths) of
+ * allowed paths that should not require authentication.
+ * 
+ * Example:
+ *    app.all('*', connect.ensureLoggedIn('/login', [
+ *      '/stylesheets/login.css',
+ *      '/javascripts/login.js',
+ *      '/images/logo.png',
+ *      '/images/favicon.png'
+ *    ]), function(req, res, next){
+ *      next(); 
+ *    });
+ *
  * Additionally, `returnTo` will be be set in the session to the URL of the
  * current request.  After authentication, this value can be used to redirect
  * the user to the page that was originally requested.
@@ -28,10 +46,11 @@
  *       function(req, res) { ... });
  *
  * @param {Object} options
+ * @param {Object} allowedPaths
  * @return {Function}
  * @api public
  */
-module.exports = function ensureLoggedIn(options) {
+module.exports = function ensureLoggedIn(options, allowedPaths) {
   if (typeof options == 'string') {
     options = { redirectTo: options }
   }
@@ -41,12 +60,19 @@ module.exports = function ensureLoggedIn(options) {
   var setReturnTo = (options.setReturnTo === undefined) ? true : options.setReturnTo;
   
   return function(req, res, next) {
-    if (!req.isAuthenticated || !req.isAuthenticated()) {
-      if (setReturnTo && req.session) {
-        req.session.returnTo = req.originalUrl || req.url;
+    if (allowedPaths !== null){
+      var _ = require('underscore');
+      if (_.contains(allowedPaths, req.path)){
+        next();
+      }else{
+        if (!req.isAuthenticated || !req.isAuthenticated()) {
+          if (setReturnTo && req.session) {
+            req.session.returnTo = req.originalUrl || req.url;
+          }
+          return res.redirect(url);
+        }
+        next();
       }
-      return res.redirect(url);
     }
-    next();
   }
 }

--- a/lib/ensureLoggedIn.js
+++ b/lib/ensureLoggedIn.js
@@ -60,19 +60,17 @@ module.exports = function ensureLoggedIn(options, allowedPaths) {
   var setReturnTo = (options.setReturnTo === undefined) ? true : options.setReturnTo;
   
   return function(req, res, next) {
-    if (allowedPaths !== null){
-      var _ = require('underscore');
-      if (_.contains(allowedPaths, req.path)){
-        next();
-      }else{
-        if (!req.isAuthenticated || !req.isAuthenticated()) {
-          if (setReturnTo && req.session) {
-            req.session.returnTo = req.originalUrl || req.url;
-          }
-          return res.redirect(url);
+    var _ = require('underscore');
+    if (_.contains(allowedPaths, req.path)){
+      next();
+    }else{
+      if (!req.isAuthenticated || !req.isAuthenticated()) {
+        if (setReturnTo && req.session) {
+          req.session.returnTo = req.originalUrl || req.url;
         }
-        next();
+        return res.redirect(url);
       }
+      next();
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,16 @@
   "name": "connect-ensure-login",
   "version": "0.1.1",
   "description": "Login session ensuring middleware for Connect.",
-  "keywords": ["connect", "express", "auth", "authn", "authentication", "login", "session", "passport"],
+  "keywords": [
+    "connect",
+    "express",
+    "auth",
+    "authn",
+    "authentication",
+    "login",
+    "session",
+    "passport"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/jaredhanson/connect-ensure-login.git"
@@ -15,12 +24,15 @@
     "email": "jaredhanson@gmail.com",
     "url": "http://www.jaredhanson.net/"
   },
-  "licenses": [ {
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT" 
-  } ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/MIT"
+    }
+  ],
   "main": "./lib",
   "dependencies": {
+    "underscore": "~1.5.1"
   },
   "devDependencies": {
     "vows": "0.6.x"
@@ -28,5 +40,7 @@
   "scripts": {
     "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js"
   },
-  "engines": { "node": ">= 0.4.0" }
+  "engines": {
+    "node": ">= 0.4.0"
+  }
 }


### PR DESCRIPTION
I found that it was convenient for me to use app.all('_', connect.ensureLoggedIn('/login'), ...) to require authentication on all paths, however I still wanted to allow /login, /signup and /about. I put those three paths above the app.all and it worked except that assets weren't loaded without authentication ('/images/_ and /stylesheets/*).

To solve this I used underscore to check an array of strings if req.path is contained and if so next, this allows me to use app.all and require authentication on all paths but still have select assets available to the login, signup, and about pages. 

Maybe there's a better way to do this, but I don't know of it and this was the best solution I had so I just wanted to share it with you.
