### PR TITLE
Added check of input arguments to original function to promote safe usability

### DIFF
--- a/lib/ensureLoggedIn.js
+++ b/lib/ensureLoggedIn.js
@@ -40,10 +40,6 @@ module.exports = function ensureLoggedIn(options) {
   var url = options.redirectTo || '/login';
   var setReturnTo = (options.setReturnTo === undefined) ? true : options.setReturnTo;
 
-  if (arguments.length === 3) {
-    return _mWare();
-  }
-
   function _mWare(req, res, next) {
     if (!req.isAuthenticated || !req.isAuthenticated()) {
       if (setReturnTo && req.session) {
@@ -52,6 +48,10 @@ module.exports = function ensureLoggedIn(options) {
       return res.redirect(url);
     }
     next();
+  }
+
+  if (arguments.length === 3) {
+    return _mWare();
   }
 
   return _mWare;

--- a/lib/ensureLoggedIn.js
+++ b/lib/ensureLoggedIn.js
@@ -33,14 +33,18 @@
  */
 module.exports = function ensureLoggedIn(options) {
   if (typeof options == 'string') {
-    options = { redirectTo: options }
+    options = { redirectTo: options };
   }
   options = options || {};
-  
+
   var url = options.redirectTo || '/login';
   var setReturnTo = (options.setReturnTo === undefined) ? true : options.setReturnTo;
-  
-  return function(req, res, next) {
+
+  if (arguments.length === 3) {
+    return _mWare();
+  }
+
+  function _mWare(req, res, next) {
     if (!req.isAuthenticated || !req.isAuthenticated()) {
       if (setReturnTo && req.session) {
         req.session.returnTo = req.originalUrl || req.url;
@@ -49,4 +53,6 @@ module.exports = function ensureLoggedIn(options) {
     }
     next();
   }
-}
+
+  return _mWare;
+};

--- a/lib/ensureLoggedIn.js
+++ b/lib/ensureLoggedIn.js
@@ -32,6 +32,10 @@
  * @api public
  */
 module.exports = function ensureLoggedIn(options) {
+
+  if (arguments.length === 3) {
+    throw Error("Please supply the return value of the call to  ensureLoggedIn to your middleware");
+  }
   if (typeof options == 'string') {
     options = { redirectTo: options };
   }
@@ -48,10 +52,6 @@ module.exports = function ensureLoggedIn(options) {
       return res.redirect(url);
     }
     next();
-  }
-
-  if (arguments.length === 3) {
-    return _mWare();
   }
 
   return _mWare;

--- a/lib/ensureLoggedIn.js
+++ b/lib/ensureLoggedIn.js
@@ -44,7 +44,9 @@ module.exports = function ensureLoggedIn(options) {
   var url = options.redirectTo || '/login';
   var setReturnTo = (options.setReturnTo === undefined) ? true : options.setReturnTo;
 
-  function _mWare(req, res, next) {
+
+
+  return function(req, res, next) {
     if (!req.isAuthenticated || !req.isAuthenticated()) {
       if (setReturnTo && req.session) {
         req.session.returnTo = req.originalUrl || req.url;
@@ -52,7 +54,5 @@ module.exports = function ensureLoggedIn(options) {
       return res.redirect(url);
     }
     next();
-  }
-
-  return _mWare;
+  };
 };

--- a/lib/ensureLoggedOut.js
+++ b/lib/ensureLoggedOut.js
@@ -27,17 +27,20 @@
  * @api public
  */
 module.exports = function ensureLoggedOut(options) {
+  if (arguments.length === 3) {
+    throw Error("Please supply the return value of the call to  ensureLoggedIn to your middleware");
+  }
   if (typeof options == 'string') {
-    options = { redirectTo: options }
+    options = { redirectTo: options };
   }
   options = options || {};
-  
+
   var url = options.redirectTo || '/';
-  
+
   return function(req, res, next) {
     if (req.isAuthenticated && req.isAuthenticated()) {
       return res.redirect(url);
     }
     next();
-  }
-}
+  };
+};


### PR DESCRIPTION
I ran into an issue running this module the other day. I forgot to call the function with ('/route') before passing it to my middleware. As a result, all of my requests to routes with this caused the response to get permanently hung up. Worst of all, there was no error message to let me know. Yes, I realize this was a usage mistake on my part, however I believe this is an easy mistake to make and costed me quite a bit of time to figure out. Because of that, I've made a small change to both ensureLoggedIn.js and ensureLoggedOut.js to throw an Error when the dev makes this same mistake.
