### PR TITLE
Allow GET redirects from non-Get, non-POST requests

### DIFF
--- a/lib/ensureLoggedIn.js
+++ b/lib/ensureLoggedIn.js
@@ -45,7 +45,7 @@ module.exports = function ensureLoggedIn(options) {
       if (setReturnTo && req.session) {
         req.session.returnTo = req.originalUrl || req.url;
       }
-      return res.redirect(url);
+      return res.redirect(303, url);
     }
     next();
   }

--- a/lib/ensureLoggedOut.js
+++ b/lib/ensureLoggedOut.js
@@ -36,7 +36,7 @@ module.exports = function ensureLoggedOut(options) {
   
   return function(req, res, next) {
     if (req.isAuthenticated && req.isAuthenticated()) {
-      return res.redirect(url);
+      return res.redirect(303, url);
     }
     next();
   }


### PR DESCRIPTION
With a plain `res.redirect(url)`, PUT requests get redirected to a PUT request of the url. I changed this to `res.redirect(303, url)`, which allows PUT requests (and other non-GET, non-POST requests) to be redirected to a GET request.

 Changes to be committed:
- modified:   lib/ensureLoggedIn.js
- modified:   lib/ensureLoggedOut.js
