### PR TITLE
Add other usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ is unauthenticated, the request will be redirected to a login page.  The URL
 will be saved in the session, so the user can be conveniently returned to the
 page that was originally requested.
 
+This middleware also prevent a route from being accessed when a user
+already login, which makes sense for login and user registration routes.
+
 ## Install
 
     $ npm install connect-ensure-login
@@ -13,18 +16,31 @@ page that was originally requested.
 
 #### Ensure Authentication
 
+`ensureLoggedIn(options)`
+
+alias: `ensureAuthenticated(options)`
+
 In this example, an application has a settings page where preferences can be
 configured.  A user must be logged in before accessing this page.
 
+
+    const { ensureLoggedIn, ensureAuthenticated } = require('connect-ensure-login');
     app.get('/settings',
-      ensureLoggedIn('/login'),
+      ensureLoggedIn('/login'), // Or ensureAuthenticated('/login')
       function(req, res) {
         res.render('settings', { user: req.user });
       });
-      
+
+
 If a user is not logged in when attempting to access this page, the request will
 be redirected to `/login` and the original request URL (`/settings`) will be
 saved to the session at `req.session.returnTo`.
+
+#### Ensure Unauthentication
+
+`ensureUnauthenticated(options)`
+
+alias: `ensureNotAuthenticated(options)` | `ensureLoggedOut(options)` | `ensureNotLoggedIn(options)`
 
 #### Log In and Return To
 
@@ -36,7 +52,7 @@ Simply mount Passport's `authenticate()` middleware at the login route.
     });
 
     app.post('/login', passport.authenticate('local', { successReturnToOrRedirect: '/', failureRedirect: '/login' }));
-    
+
 Upon log in, Passport will notice the `returnTo` URL saved in the session and
 redirect the user back to `/settings`.
 


### PR DESCRIPTION
Hi Jared,

Thanks for this great package! I'm making this pull request to try to solve the following issues.

In the issues #4 and #21 they suggest updating README to show how to import `ensureLoggedIn()`. I add this to README.

Also by reading your source code, I notice this package also have a function to prevent a route from being accessed when a user already login, I also add it to README.