### PR TITLE
Update example for passport 0.6.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Simply mount Passport's `authenticate()` middleware at the login route.
       res.render('login');
     });
 
-    app.post('/login', passport.authenticate('local', { successReturnToOrRedirect: '/', failureRedirect: '/login' }));
+    app.post('/login', passport.authenticate('local', { keepSessionInfo: true, successReturnToOrRedirect: '/', failureRedirect: '/login' }));
     
 Upon log in, Passport will notice the `returnTo` URL saved in the session and
 redirect the user back to `/settings`.


### PR DESCRIPTION
As of passport 0.6.0, the `keepSessionInfo` option is required or else `session.returnTo` is lost when the session is regenerated upon login